### PR TITLE
Can now specify custom decoder when instantiating Microphone

### DIFF
--- a/respeaker/microphone.py
+++ b/respeaker/microphone.py
@@ -67,7 +67,7 @@ class Microphone:
     detecting_mask = (1 << 1)
     recording_mask = (1 << 2)
 
-    def __init__(self, pyaudio_instance=None, quit_event=None):
+    def __init__(self, pyaudio_instance=None, quit_event=None, decoder=None):
         pixel_ring.set_color(rgb=0x400000)
 
         self.pyaudio_instance = pyaudio_instance if pyaudio_instance else pyaudio.PyAudio()
@@ -98,7 +98,7 @@ class Microphone:
         self.listen_queue = Queue.Queue()
         self.detect_queue = Queue.Queue()
 
-        self.decoder = self.create_decoder()
+        self.decoder = decoder if decoder else self.create_decoder()
         self.decoder.start_utt()
 
         self.status = 0


### PR DESCRIPTION
This is also useful if you want to use the Microphone's listen() method
without setting up a pocketpshinx decoder, by specifying a dummy decoder:

    class DummyDecoder(object):
        def start_utt(): pass

    mic = Microphone(decoder=DummyDecoder())
    data = mic.listen(duration=5, timeout=1)
    # Do stuff with data, like UDP stream to server.

Signed-off-by: Edouard Poitras <edouardpoitras@gmail.com>