### PR TITLE
To select default device when respeaker device is not available.

### DIFF
--- a/respeaker/microphone.py
+++ b/respeaker/microphone.py
@@ -82,6 +82,9 @@ class Microphone:
                 self.device_index = i
                 break
 
+        if not self.device_index:
+            device = self.pyaudio_instance.get_default_input_device_info()
+            self.device_index = device['index']
         self.stream = self.pyaudio_instance.open(
             input=True,
             start=False,

--- a/respeaker/vad.py
+++ b/respeaker/vad.py
@@ -66,7 +66,7 @@ class WebRTCVAD:
                     break
                 elif len(self.history) == self.history.maxlen and sum(self.history) == 0:
                     sys.stdout.write('Todo: increase capture volume')
-                    for _ in range(self.history.maxlen / 2):
+                    for _ in range(self.history.maxlen // 2):
                         self.history.popleft()
 
             else:


### PR DESCRIPTION
When using independently the if condition:

`if name.lower().find(b'respeaker') >= 0 and dev['maxInputChannels'] > 0:`

Never satisfies and device_index doesn't get set. Later logic continues to create a stream object using None as device index, instead setting it to default device returned from `pyaudio_instance.get_default_input_device_info()` to handle things correctly.