### PR TITLE
Fix call to hid.enumerate()

### DIFF
--- a/respeaker/usb_hid/hidapi_backend.py
+++ b/respeaker/usb_hid/hidapi_backend.py
@@ -53,7 +53,7 @@ class HidApiUSB(Interface):
         returns an array of HidApiUSB (Interface) objects
         """
 
-        devices = hid.enumerate()
+        devices = hid.enumerate(0,0)
 
         if not devices:
             logging.debug("No Mbed device connected")


### PR DESCRIPTION
The current version of hidapi expects argumentes to be passed in

This was on OSX with python 2.7.9, I'm not entirely sure if this is needed on other platforms where hidapi *might* be different.